### PR TITLE
feat: move from config_aqua

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,11 @@ repos:
       - id: yamllint
         args:
           - -c=.config/.yamllint
+        exclude: |
+          (?x)^(
+            backup/[\d|\w|_]+\/(.*?)|
+            aqua.yaml
+          )$
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.3.0

--- a/Taskfile.aqua.yml
+++ b/Taskfile.aqua.yml
@@ -1,0 +1,169 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+# https://taskfile.dev/
+
+version: "3"
+
+vars:
+  # 一連の処理のエラーを捕捉（_gitで使用する）
+  # 以前は defer で task に vars が渡せていたが、v3.39.0 あたりでエラーになって以降
+  # 修正されておらず、グローバルに切り出して対応することにした
+  ON_ERROR: /tmp/on_error_aqua
+
+tasks:
+  default:
+    cmds:
+      - task --list --sort alphanumeric -t {{.TASKFILE}}
+      - echo ""
+      - echo -n "reminder this package "
+      - task: aqua:packages
+    silent: true
+
+  util:list:
+    # desc: view all tasks
+    summary: |
+      全タスクの出力
+    aliases:
+      - ul
+      - ls
+    cmd: task --list-all --sort alphanumeric
+    silent: true
+
+  util:summary:
+    # desc: view summary of all tasks
+    summary: |
+      全タスクのサマリー出力
+    aliases:
+      - us
+      - la
+    cmd: task --list-all --sort alphanumeric -j | jq -cr ".tasks[].name" | xargs -i sh -c 'task --summary {}; echo "\n---\n"'
+    silent: true
+
+  aqua:alias:
+    desc: show alias for aqua
+    summary: |
+      aqua のエイリアスを表示
+      profile を引き継がないので alias コマンドから grep では表示できないのでベタ書き
+    aliases:
+      - aa
+    cmds:
+      - |
+        cat <<EOF
+        alias aqgi='aqua generate -i -o $AQUA_GLOBAL_CONFIG'
+        alias aqia='aqua install --all'
+        alias aqli='aqua list --installed --all | sort'
+        alias aqup='aqua update'
+        EOF
+    silent: true
+
+  aqua:packages:
+    desc: random package from aqua.yaml
+    aliases:
+      - ap
+    vars:
+      AQUA_YAML_FILE:
+        sh: cat aqua.yaml
+        # yq を強要せずに aqua.yaml の内容を取得する
+      AQUA_YAML_DATA:
+        ref: fromYaml .AQUA_YAML_FILE
+        # YAML をパースしてデータを取得
+      AQUA_YAML_DATA_LENGTH:
+        ref: len .AQUA_YAML_DATA.packages
+        # パッケージの数を取得
+      RANDOM_PACKAGE:
+        ref: index .AQUA_YAML_DATA.packages (randInt 0 .AQUA_YAML_DATA_LENGTH)
+        # ランダムなパッケージを取得
+    cmds:
+      - echo "{{.RANDOM_PACKAGE.name}}"
+    silent: true
+
+  aqua:update:
+    desc: Run aqua update, install, list for globally
+    aliases:
+      - au
+    dir: ~/.config/aqua
+    dotenv:
+      - .env
+    cmds:
+      - echo "use github token [${GITHUB_TOKEN:0:20}***]"
+      - aqua update
+      - aqua install -all
+      - aqua list --installed --all | sort
+
+  aqua:git:
+    desc: auto git, use -- COMMIT TITLE
+    summary: |
+      aqua update の結果を自動で登録
+      task ag -- コミットタイトル（の一部）
+    aliases:
+      - ag
+    cmds:
+      - task: _git
+        vars:
+          TITLE: 'bump: aqua up at {{date "2006-01-02" now}} {{.CLI_ARGS}}'
+          BRANCH: 'bump/aqua_up/{{date "2006-01-02" now}}'
+          TARGET: "aqua.yaml"
+
+  _git:
+    summary: git automation
+    requires:
+      vars:
+        - TITLE
+        - BRANCH
+        - TARGET
+    cmds:
+      - defer:
+          task: _git:on_error
+      - touch {{.ON_ERROR}}
+      - task: _git:auto
+        vars:
+          TITLE: "{{.TITLE}}"
+          BRANCH: "{{.BRANCH}}"
+          TARGET: "{{.TARGET}}"
+      - task: _git:gh
+        vars:
+          TITLE: "{{.TITLE}}"
+          BRANCH: "{{.BRANCH}}"
+      - git fetch --prune --all
+      - task: _git:status
+      - rm {{.ON_ERROR}}
+
+  _git:auto:
+    summary: |
+      git add, commit, push までを自動化
+    cmds:
+      - git fetch --prune --all
+      - git checkout origin/HEAD
+      - git add {{.TARGET}}
+      - git commit -m"{{.TITLE}}"
+      - git push origin HEAD:refs/heads/{{.BRANCH}} -f
+
+  _git:gh:
+    summary: |
+      - GitHub CLI を使用して PR を作成し、オートマージを設定する
+      - push 前までと分離しているのは、エラー時の処理が異なるため
+        - push 前までのエラーは reset して処理前に戻す
+        - push 後のエラーは push を再処理する（ON_ERROR のファイルに保存）
+      - PAT の権限がちゃんとしてないとエラーになることに注意
+      - オートマージの設定もリポジトリ側に必要
+    cmds:
+      - gh pr create -t "{{.TITLE}}" -b "" -l "" -H "{{.BRANCH}}" -B "main"
+      - sleep 1
+      - gh pr merge "{{.BRANCH}}" --auto -s
+      - sleep 2
+
+  _git:status:
+    internal: true
+    cmds:
+      - git plog -5
+      - git status --short --branch
+
+  _git:on_error:
+    internal: true
+    silent: true
+    status:
+      - test ! -e {{.ON_ERROR}}
+    cmds:
+      - defer: rm {{.ON_ERROR}}
+      - cmd: git reset --mixed origin/HEAD
+        ignore_error: true
+      - task: _git:status

--- a/aqua.md
+++ b/aqua.md
@@ -1,0 +1,77 @@
+# .config/aqua
+
+- [CLI バージョン管理ツールの aqua を使うようになって少し経ったので少しまとめておく](https://zenn.dev/raki/articles/2024-05-16_aqua)
+
+## aqua.yaml のパッケージをソート
+
+```bash
+# yq も aqua でインストーつできるので入れておくといい
+yq '.packages |= sort_by(.name | split("/") | .[1])' aqua.yaml
+```
+
+- 管理に迷ったらソートしておくと見やすい（かも）
+- 関連ツール毎にまとめたい時は [Split the list of packages](https://aquaproj.github.io/docs/guides/split-config) を使うとよさげ
+
+## .bashrc
+
+```bash
+# cli version manager aqua
+export PATH="$(aqua root-dir)/bin:$PATH"
+export AQUA_GLOBAL_CONFIG=${XDG_CONFIG_HOME:-$HOME/.config}/aqua/aqua.yaml
+```
+
+## alias
+
+```bash
+alias aq='aqua'
+alias aqcd="cd ${XDG_CONFIG_HOME:-$HOME/.config}/aqua/"
+alias aqgi='aqua generate -i -o $AQUA_GLOBAL_CONFIG'
+alias aqia='aqua install --all'
+alias aqli='aqua list --installed --all | sort'
+alias aqup='aqua update'
+```
+
+## task
+
+```bash
+$ aqcd
+aqua $ task
+task: Available tasks for this project:
+* aqua:alias:          show alias for aqua                              (aliases: aa)
+* aqua:git:            auto git, use -- COMMIT TITLE                    (aliases: ag)
+* aqua:packages:       random package from aqua.yaml                    (aliases: ap)
+* aqua:update:         Run aqua update, install, list for globally      (aliases: au)
+
+reminder this package cli/cli@v2.76.2
+
+aqua $ task ls
+task: Available tasks for this project:
+* _git:
+* _git:auto:
+* _git:gh:
+* aqua:alias:          show alias for aqua                              (aliases: aa)
+* aqua:git:            auto git, use -- COMMIT TITLE                    (aliases: ag)
+* aqua:packages:       random package from aqua.yaml                    (aliases: ap)
+* aqua:update:         Run aqua update, install, list for globally      (aliases: au)
+* default:
+* util:list:                 (aliases: ul, ls)
+* util:summary:              (aliases: us, la)
+
+aqua $ task au
+<omit> aqua up が実行される
+
+aqua $ task ag
+<omit> git add aqua.yaml から commit, push, gh pr create, gh pr merge まで自動化
+```
+
+## direnv
+
+- .direnv と .env で GitHub token を設定した
+- [Tips ｜ aqua CLI Version Manager 入門](https://zenn.dev/shunsuke_suzuki/books/aqua-handbook/viewer/tips#github_token%2C-aqua_github_token-%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6-rate-limit-%E3%82%92%E5%9B%9E%E9%81%BF%E3%81%99%E3%82%8B)
+
+# related my projects
+
+- [officel/config_aqua: .config/aqua](https://github.com/officel/config_aqua)
+- [officel/config_bash: .config/bash](https://github.com/officel/config_bash)
+- [officel/config_git: .config/git](https://github.com/officel/config_git)
+- [officel/config_task: .config/task](https://github.com/officel/config_task)

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,56 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.450.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: cli/cli@v2.83.2
+- name: volta-cli/volta@v2.0.2
+- name: golang/go@go1.25.5
+- name: nektos/act@v0.2.83
+- name: jqlang/jq@jq-1.8.1
+- name: mikefarah/yq@v4.50.1
+- name: google/yamlfmt@v0.20.0
+- name: direnv/direnv@v2.37.1
+- name: stateful/runme@v3.16.4
+- name: aws/aws-cli@2.32.26
+- name: 99designs/aws-vault@v7.2.0
+- name: charmbracelet/glow@v2.1.1
+- name: kayac/ecspresso@v2.7.0
+- name: ericchiang/pup@v0.4.0
+- name: tfutils/tfenv@v3.0.0
+- name: terraform-linters/tflint@v0.60.0
+- name: hashicorp/levant@v0.4.0
+- name: hashicorp/packer@v1.14.3
+- name: kubernetes/kubectl@v1.35.0
+- name: kubernetes/kubeadm@v1.35.0
+- name: kubernetes-sigs/kind@v0.31.0
+- name: helm/helm@v4.0.4
+- name: derailed/k9s@v0.50.16
+- name: kubecolor/kubecolor@v0.5.3
+- name: argoproj/argo-cd@v3.2.3
+- name: istio/istio/istioctl@1.28.2
+- name: go-task/task@v3.46.4
+- name: newrelic/newrelic-cli@v0.106.8
+- name: astral-sh/uv@0.9.21
+- name: neilotoole/sq@v0.48.10
+- name: terraform-docs/terraform-docs@v0.21.0
+- name: marp-team/marp-cli@v4.2.3
+- name: 01mf02/jaq@v2.3.0
+- name: Azure/kubelogin@v0.2.13
+- name: anchore/grype@v0.104.3
+- name: j178/prek@v0.2.25
+- name: hairyhenderson/gomplate@v4.3.3
+- name: hashicorp/vault@v1.21.1
+- name: aquasecurity/trivy@v0.68.2
+- name: miniscruff/changie@v1.24.0
+- name: twistedpair/google-cloud-sdk@550.0.0
+- name: ajeetdsouza/zoxide@v0.9.8
+- name: junegunn/fzf@v0.67.0
+- name: Orange-OpenSource/hurl@7.1.0


### PR DESCRIPTION
- config_aqua から引っ越してきてもらう
- pre-commit を使っていなかったので yaml エラーが出るのを無視させる
- `~/.config/aqua` のシンボリックリンクをこのリポジトリに手動で向け直している