### PR TITLE
feat: move from config_git

### DIFF
--- a/allowed_signers
+++ b/allowed_signers
@@ -1,0 +1,1 @@
+officel@users.noreply.github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOst8/Mo2OcFQRvi94lNe8pjMxOUh4BiW+NO60+ez0cG

--- a/config
+++ b/config
@@ -1,0 +1,89 @@
+[user]
+	name = NISHIMURA Yoshitaka
+	email = officel@users.noreply.github.com
+	signingKey = ~/.ssh/id_ed25519.pub
+
+[commit]
+	gpgSign = true
+	# template = ~/.config/git/git_commit_conventions.txt
+
+[gpg]
+	format = ssh
+
+[gpg "ssh"]
+	allowedSignersFile = ~/.config/git/allowed_signers
+
+[advice]
+	detachedHead = false
+
+[alias]
+	# short
+	co = checkout
+	sw = switch
+	swo= switch -d origin/HEAD
+
+	# alias
+	cancel = reset --soft HEAD^
+	save   = stash save
+	load   = stash pop
+	pr     = "!git push origin HEAD:refs/heads/$1 #"
+	uns    = restore --staged
+	unt    = ls-files --others --exclude-standard
+	ign    = ls-files --others --exclude-standard --ignored
+	recent = branch --sort=-committerdate --format='%(committerdate:relative)%09%(refname:short)'
+	last   = log -1 HEAD --stat
+
+	# options
+	alias  = !git config --get-regexp 'alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
+	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format-local:'%t%Y/%m/%d %H:%M' --graph
+
+	deleted   = log --diff-filter=D --summary
+	restoring = !git checkout $(git rev-list -n 1 HEAD -- "${1:-none}")~1 --
+	chash     = rev-parse --short HEAD
+	goback    = "!git checkout $(git name-rev --name-only --exclude=refs/tags/\\* @{-${1:-1}}) #"
+
+[core]
+	autocrlf = false
+	commentChar = ";"
+	editor = vim +startinsert
+	fileMode = false
+	ignoreCase = false
+	quotePath  = false
+
+[diff]
+	compactionHeuristic = true
+	wsErrorHighlight = all
+
+[fetch]
+	prune = true
+	pruneTags = true
+
+[grep]
+	lineNumber = true
+
+[help]
+	autoCorrect = 1
+
+[init]
+	defaultBranch = main
+
+[log]
+	follow = true
+
+[push]
+	default = current
+
+[rebase]
+  autoSquash = true
+  autoStash = true
+  updateRefs = true
+
+[rerere]
+  enabled = true
+
+[credential "https://github.com"]
+  helper =
+	helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+  helper =
+	helper = !gh auth git-credential

--- a/git.md
+++ b/git.md
@@ -1,0 +1,65 @@
+# config_git
+
+my git config on $XDG_CONFIG_HOME/git/
+
+## usage
+
+```bash
+cd ~/.config  # $XDG_CONFIG_HOME or $HOME/.config
+git clone https://github.com/officel/config_git.git ./git
+
+# or I do it this way
+cd ~/repos/github.com/officel/
+git clone https://github.com/officel/config_git.git
+ln -s ~/repos/github.com/officel/config_git/ ~/.config/git
+```
+
+- install id_rsa (manual)
+- fix git config remote.origin.url after clone
+
+## see
+
+- [Git - git-config Documentation](https://git-scm.com/docs/git-config)
+- [GitAlias/gitalias: Git alias commands for faster easier version control](https://github.com/GitAlias/gitalias)
+- [github/gitignore: A collection of useful .gitignore templates](https://github.com/github/gitignore)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+
+# related my projects
+
+- [officel/config_aqua: .config/aqua](https://github.com/officel/config_aqua)
+- [officel/config_bash: .config/bash](https://github.com/officel/config_bash)
+- [officel/config_git: .config/git](https://github.com/officel/config_git)
+- [officel/config_task: .config/task](https://github.com/officel/config_task)
+
+# note
+
+## ローカルリポジトリだけ ignore
+
+- チームでは ignore しないが、個人では ignore したい
+- 個人の共通設定（このリポジトリの ignore のように）では ignore しないが、特定のリポジトリでは ignore したい
+- （リポジトリの）`.git/info/exclude` に追加
+
+## config がどこで設定されているか
+
+- Windows ユーザの同僚氏のグローバルな git の設定の場所がぱっとわからなかった
+- `git config --show-origin --show-scope --list`
+
+## global の config
+
+- [Git - Git Configuration](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)
+- `~/.gitconfig` か `~/.config/git/config`
+
+> The next place Git looks is the ~/.gitconfig (or ~/.config/git/config) file, which is specific to each user.
+> You can make Git read and write to this file by passing the --global option.
+
+## commit 時に自動改行させない
+
+- git のコミット本文は 72 文字でデフォルトで自動改行される
+- `textwidth=0` にすればいいらしいので、`/.vimrc` で設定
+- あまり長いのは推奨されないので適度に自分で改行すること
+
+```text
+# ~/.vimrc
+autocmd FileType gitcommit setlocal textwidth=0
+```

--- a/ignore
+++ b/ignore
@@ -1,0 +1,23 @@
+.DS_Store
+.env
+.envrc
+*.swp
+
+# temporary file
+*.nogit
+*.nogit.md
+__*
+
+# ansible-vault password file in repo
+.vault_password
+
+# for act(github actions localy)
+.act.secrets
+.act.env
+
+# terraform
+.terraform/
+.terraformrc
+terraform.tfstate
+terraform.tfstate.backup
+z.tfstate


### PR DESCRIPTION
- config_git から引っ越してきてもらう
- ファイル名がシンプルだと統一ディレクトリ配下ではわかりにくいかもな。要検討