### PR TITLE
fix: remove alias GitHub CLI Copilot extension

### DIFF
--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -101,11 +101,6 @@ alias gss='git show --stat'
 alias gst='git status --short --branch'
 alias cr='cd "$(git rev-parse --show-toplevel)"'
 
-# GitHub Copilot
-alias ghc='gh copilot'
-alias ghcs='gh copilot suggest'
-alias ghce='gh copilot explain'
-
 # k8s use kubecolor
 alias k='kubecolor'
 alias kubectl='kubecolor'


### PR DESCRIPTION
- Copilot CLI が GA したので機能拡張版は正式にリタイアだそうなのでいったん alias を削除
- Copilot CLI は copilot コマンドらしいので gh はじまりにする必要がない（してもいいけど）
- gc は別のコマンドとぶつかるだろうし c かなぁ。。。