### PR TITLE
feat: use GitHub Copilot CLI

### DIFF
--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -54,3 +54,4 @@ packages:
 - name: ajeetdsouza/zoxide@v0.9.9
 - name: junegunn/fzf@v0.68.0
 - name: Orange-OpenSource/hurl@7.1.0
+- name: github/copilot-cli@v0.0.418


### PR DESCRIPTION
- https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available/
- GA のお知らせがあったので GitHub CLI の機能拡張版と入れ替え