### PR TITLE
fix: use environment variable _ZO_EXCLUDE_DIRS

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -192,4 +192,5 @@ export PATH="$HOME/.volta/bin:$PATH"
 export PATH="$HOME/go/bin:$PATH"
 
 # cd alternative zoxide
+export _ZO_EXCLUDE_DIRS="/tmp/*:/mnt/c/*:/mnt/d/*"
 eval "$(zoxide init bash)"


### PR DESCRIPTION
- zoxide で Windows 側ディレクトリと WSL2 側でシンボリックリンク貼ったディレクトリでダブるので /mnt を対象外にした

```bash
# 現在存在するディレクトリ
zoxide query --list

zoxide remove /path/to/unwanted/dir

zoxide query --list | grep 'xxx' | xargs -r zoxide remove

# 確認しながら消すなら
zoxide query --list | fzf --multi | xargs -r zoxide remove
```