### PR TITLE
feat: git alias drop is git stash drop

### DIFF
--- a/git/config
+++ b/git/config
@@ -26,6 +26,7 @@
 	cancel = reset --soft HEAD^
 	save   = stash save
 	load   = stash pop
+	drop   = stash drop
 	pr     = "!git push origin HEAD:refs/heads/$1 #"
 	uns    = restore --staged
 	unt    = ls-files --others --exclude-standard


### PR DESCRIPTION
- git stasg delete って打ってしまう
- git alias で常に alias の確認ができるのでしゅっとでるようにした
- `git stash drop stash[{0}` が正しい使い方だけどひとつしかないなら `g drop` でいけるというワケ