### PR TITLE
feat: use pinact

### DIFF
--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -55,3 +55,4 @@ packages:
 - name: Orange-OpenSource/hurl@7.1.0
 - name: github/copilot-cli@v1.0.9
 - name: nodejs/node@v25.8.1
+- name: suzuki-shunsuke/pinact@v3.9.0


### PR DESCRIPTION
- trivy のニ回目のサプライチェーン攻撃を見てもう逃げられないなと
- koki 先生の記事に従って pinact を導入
- https://zenn.dev/kou_pg_0131/articles/gha-should-be-pinned