### PR TITLE
feat: global task

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -25,6 +25,7 @@ vars:
   USER_HOME_LINKS:
     - "direnvrc,.direnvrc"
     - "vimrc,.vimrc"
+    - "Taskfile.home.yml,Taskfile.yml"
   # XDG_CONFIG_HOME 環境変数のデフォルト値
   XDG_CONFIG_HOME: "~/.config"
   # XDG_CONFIG_HOME にシンボリックリンクを作成するディレクトリのリスト

--- a/Taskfile.home.yml
+++ b/Taskfile.home.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+# home ディレクトリに配置してグローバルな作業を行う
+# リポジトリに既に taskfile が存在する場合は `t -g` で呼べる
+
+# vars:
+
+tasks:
+  default:
+    cmds:
+      - echo "This is {{.TASKFILE}} at v{{.TASK_VERSION}}"
+      - task --list --sort alphanumeric -t {{.TASKFILE}}
+    silent: true
+
+  repos:use_prek:
+    desc: "prek への切替実行"
+    summary: |
+      - pre-commit を prek へ切り替える。
+      - 何度実行しても問題ない。
+      - WF の名前は pre-commit に統一する（grep でチェック）
+    aliases:
+      - up
+    cmds:
+      - pre-commit uninstall
+      - prek install
+      - prek autoupdate --freeze
+      - pinact run -u
+      - git grep -i -p "prek" || echo "No 'prek' found in the repository."
+      - grep "groups" .github/dependabot.yml || echo "No 'groups' found in .github/dependabot.yml."
+    dir: "{{.USER_WORKING_DIR}}"


### PR DESCRIPTION
- ホームディレクトリに Taskfile.yml を設定してグローバルに使えるようにする
- dependabot のグループ化はついで
- pre-commit から prek に乗り換える処理を自動化