### PR TITLE
feat: use zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -21,3 +23,5 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: prek
+name: pre-commit
 
 on:
   workflow_dispatch:
@@ -13,4 +13,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: j178/prek-action@79f765515bd648eb4d6bb1b17277b7cb22cb6468 # v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # https://pre-commit.com/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-json
         exclude: |
@@ -22,12 +22,18 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: 393031adb9afb225ee52ae2ccd7a5af5525e03e8  # frozen: v1.7.11
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # frozen: v1.23.1
+    hooks:
+      - id: zizmor
+
+
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.36
+    rev: 6d3c1b70d44ea2202b23552af93aca3b5017ee83  # frozen: v0.9.36
     hooks:
       - id: pymarkdown
         args:
@@ -41,7 +47,7 @@ repos:
           )$
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.38.0
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
     hooks:
       - id: yamllint
         args:
@@ -53,7 +59,7 @@ repos:
           )$
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.4.0
+    rev: 91ab4bf57e58b32adf1a122681f6ebe164d081c8  # frozen: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/Taskfile.home.yml
+++ b/Taskfile.home.yml
@@ -22,7 +22,7 @@ tasks:
     aliases:
       - up
     cmds:
-      - pre-commit uninstall
+      - pre-commit uninstall || echo "pre-commit not found, skipping uninstall."
       - prek install
       - prek autoupdate --freeze
       - pinact run -u

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -56,3 +56,4 @@ packages:
 - name: github/copilot-cli@v1.0.9
 - name: nodejs/node@v25.8.1
 - name: suzuki-shunsuke/pinact@v3.9.0
+- name: zizmorcore/zizmor@v1.23.1


### PR DESCRIPTION
- pre-commit のピン留めが終わってなかった
- GitHub Actions の静的解析ツール zizmor を追加
- 出力されたエラーに対応
- pre-commit uninstall 時に（pre-commit 自体をシステムから消したため）エラーになるのをスキップすることにした