### PR TITLE
fix: remove alias from git alias

### DIFF
--- a/git/config
+++ b/git/config
@@ -19,8 +19,6 @@
 [alias]
 	# short
 	co = checkout
-	sw = switch
-	swo= switch -d origin/HEAD
 
 	# alias
 	cancel = reset --soft HEAD^


### PR DESCRIPTION
- switch まったく使わないので削除
- checkout が使えなくなるなら、と思って入れてたけど別になくならないのでまぁいいか