### PR TITLE
chore: しばらく放置してた分をコミットしておく

### DIFF
--- a/Taskfile.home.yml
+++ b/Taskfile.home.yml
@@ -2,7 +2,14 @@
 version: "3"
 
 # home ディレクトリに配置してグローバルな作業を行う
-# リポジトリに既に taskfile が存在する場合は `t -g` で呼べる
+# リポジトリに既に taskfile が存在する場合は `t -g` または `tg`
+
+includes:
+  repos:
+    taskfile: Taskfile.repos.yml
+    flatten: true
+    internal: false
+    optional: true
 
 # vars:
 

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -94,7 +94,7 @@ alias gdww='git diff --no-index --word-diff --word-diff-regex='\''[A-Za-z0-9]+|[
 # zoxide と一緒に fzf を入れたので、ログからハッシュを取得しやすいようにした(git find commit 的な)
 alias gfc='git log --all --oneline --graph --decorate -50 | fzf --no-multi | grep -oE '\''[a-f0-9]{7}'\'' | head -c -1'
 # リストからブランチを選択してチェックアウト
-alias gfo='git branch --all --sort=-refname | fzf --no-multi | xargs git checkout '
+alias gfo='git branch --all --sort=-refname | grep -v -e HEAD | fzf --no-multi | xargs git checkout '
 alias gg='git grep -i -P'
 alias glogs='git log -S'
 

--- a/git/config
+++ b/git/config
@@ -98,3 +98,5 @@
 [credential "https://gist.github.com"]
   helper =
 	helper = !gh auth git-credential
+[lfs "ssh"]
+	automultiplex = false


### PR DESCRIPTION
- Taskfile はここの管理下に置かないローカル向け別ファイルの読み込みを追加している
- gfo は zoxide + fzf に感化されて git branch を選択して co できるようにしている
- gfo の先頭で git fetch --all --prune してみてたんだけど、待ち時間がちょっとうざいのでやめた
- 必要なら gr してからすればいいので gfo は検索だけをさせる
- git/config ssh セクションは WSL2 で automultiplex を false にすると切れにくいって聞いたんだけど、効果がいまいちわかってない
- とりあえずこの状態で運用していて問題なかったのでまぁいいか的な判断（ずっと差分で置いておくのだるい）