### PR TITLE
feat: use ryl

### DIFF
--- a/.config/.ryl.toml
+++ b/.config/.ryl.toml
@@ -1,0 +1,56 @@
+ignore = [
+    "backup/",
+    "node_modules/",
+    "Taskfile.git.yml",
+]
+
+[files]
+yaml = [
+    "*.yaml",
+    "*.yml",
+    ".yamllint",
+]
+
+[rules]
+anchors = "enable"
+braces = "enable"
+brackets = "enable"
+colons = "enable"
+commas = "enable"
+document-end = "disable"
+document-start = "disable"
+empty-values = "disable"
+float-values = "disable"
+hyphens = "enable"
+indentation = "enable"
+key-duplicates = "enable"
+key-ordering = "disable"
+new-line-at-end-of-file = "enable"
+octal-values = "disable"
+quoted-strings = "disable"
+trailing-spaces = "enable"
+
+[rules.comments]
+level = "warning"
+
+[rules.comments-indentation]
+level = "warning"
+
+[rules.empty-lines]
+level = "warning"
+
+[rules.line-length]
+allow-non-breakable-inline-mappings = false
+allow-non-breakable-words = true
+max = 160
+
+[rules.new-lines]
+level = "warning"
+
+[rules.truthy]
+allowed-values = [
+    "true",
+    "false",
+]
+check-keys = false
+level = "warning"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,14 @@ repos:
         args:
           - -c=.config/.yamllint
 
+  - repo: https://github.com/owenlamont/ryl-pre-commit
+    rev: 75e565ff428fb9bad213c3c76d1bde37ffeb8fcf  # frozen: v0.15.0
+    hooks:
+      - id: ryl
+        types_or: [yaml, markdown]
+        args:
+          - -c=.config/.ryl.toml
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: 91ab4bf57e58b32adf1a122681f6ebe164d081c8  # frozen: v4.4.0
     hooks:

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -881,6 +881,31 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/owenlamont/ryl/v0.15.0/ryl-aarch64-apple-darwin.tar.gz",
+      "checksum": "0AC4A6A6D014B63A248C696A99EE556753A7EBA23980E873B2D966793B8FDB0A",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/owenlamont/ryl/v0.15.0/ryl-aarch64-pc-windows-msvc.zip",
+      "checksum": "E421D42411A9395D3268C000AFFADA8D1739AF05FECCE1B476830CCF1886D107",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/owenlamont/ryl/v0.15.0/ryl-aarch64-unknown-linux-musl.tar.gz",
+      "checksum": "0B73BDB9AABD0F9462163D8DD79B06D8E72513C6471E72AB63E74D4B923D0E7B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/owenlamont/ryl/v0.15.0/ryl-x86_64-pc-windows-msvc.zip",
+      "checksum": "E22250F4B2F04B50DEF5BF772416F7A93FC17A184C7F6B1BA2BEEE4DB4F90EB0",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/owenlamont/ryl/v0.15.0/ryl-x86_64-unknown-linux-musl.tar.gz",
+      "checksum": "F506DC124F29C8F3428BACBD28E90BAF9FC8824DAA3A21E48E3B1F9DA68A8490",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/runmedev/runme/v3.16.11/runme_darwin_arm64.tar.gz",
       "checksum": "0DAF3CFEE447DC4C31D98B916F8CB05BEDDF1AC6CF1750B9A4E975DB0F3BB02D",
       "algorithm": "sha256"

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -60,3 +60,4 @@ packages:
   - name: BurntSushi/ripgrep@15.1.0
   - name: sharkdp/fd@v10.4.2
   - name: dandavison/delta@0.19.2
+  - name: owenlamont/ryl@v0.15.0


### PR DESCRIPTION
- [ryl -- yamllint の代替ツールを探して](https://zenn.dev/raki/articles/2026-06-11_yamllint_alternative)